### PR TITLE
Minor grammatical fix and added new functions

### DIFF
--- a/nerdamer.core.js
+++ b/nerdamer.core.js
@@ -3806,6 +3806,15 @@ var nerdamer = (function() {
         }
         return this;
     };
+
+    /**
+     * Clear the variables from the VARS object;
+     * @returns {Object} Returns the nerdamer object
+     */    
+    libExports.clearVars = function() {
+        VARS = {};
+        return this;
+    };
     
     libExports.addPreprocessor = function(f) {
         return PREPROCESSORS.push(f);

--- a/nerdamer.core.js
+++ b/nerdamer.core.js
@@ -3808,7 +3808,7 @@ var nerdamer = (function() {
     };
 
     /**
-     * Clear the variables from the VARS object;
+     * Clear the variables from the VARS object
      * @returns {Object} Returns the nerdamer object
      */    
     libExports.clearVars = function() {

--- a/nerdamer.core.js
+++ b/nerdamer.core.js
@@ -3820,18 +3820,17 @@ var nerdamer = (function() {
      * @param {String} Output format. Can be 'object' (just returns the VARS object), 'text' or 'latex'. Default: 'text'
      * @returns {Object} Returns an object with the variables
      */    
-    libExports.getVars = function(output = 'text') {
+    libExports.getVars = function(output) {
+        output = output || 'text';
         var variables = {};
-        for (var v in VARS) {
-            if (output == 'object') {
-                variables = VARS;
-                break;
-            }
-            
-            if (output == 'latex') {
-                variables[v] = VARS[v].latex();
-            } else if (output == 'text') {
-                variables[v] = VARS[v].text();
+        if (output === 'object') variables = VARS;
+        else {
+            for (var v in VARS) {
+                if (output === 'latex') {
+                    variables[v] = VARS[v].latex();
+                } else if (output === 'text') {
+                    variables[v] = VARS[v].text();
+                }
             }
         }
         return variables;


### PR DESCRIPTION
Minor grammatical fix. Error message changed from "function **tranpose** expects a matrix" to "function **transpose** expects a matrix".

Added function `libExports.clearVars` to reset the `VARS` object to `{}`.

Added function `libExports.getVars` to get the variables. Returns an object and accept one of the following arguments:

* `object`
* `text`
* `latex`

The argument is applied to the value of the variable.