### PR TITLE
Update tests 201703

### DIFF
--- a/spec/LaTeX.spec.js
+++ b/spec/LaTeX.spec.js
@@ -158,8 +158,8 @@ describe('TeX features', function () {
             var decimalTex = nerdamer(testCases[i].given).toTeX('decimal');
 
             // then
-            expect(teX).toEqual(testCases[i].TeX);
-            expect(decimalTex).toEqual(testCases[i].decimalTeX);
+            expect(teX).toEqual(testCases[i].TeX, 'for formula ' + testCases[i].given);
+            expect(decimalTex).toEqual(testCases[i].decimalTeX, 'for formula ' + testCases[i].given);
         }
     });
 

--- a/spec/calculus.spec.js
+++ b/spec/calculus.spec.js
@@ -387,4 +387,106 @@ describe('calculus', function () {
             expect(parsed.toString()).toEqual(testCases[i].expected);
         }
     });
+
+    // TODO ljacqu 20170328: Change test cases to typical given / expected structure
+    it('should handle minus sign properly', function () {
+      // given
+      var cases = {
+          '0-4': {
+              expected: '-4'
+          },
+          '-(4)': {
+              expected: '-4'
+          },
+          '3*-(4)': {
+              expected: '-12'
+          },
+          '-3*-(4)': {
+              expected: '12'
+          },
+          '-(3*-(4))': {
+              expected: '12'
+          },
+          '-(-3*-(4))': {
+              expected: '-12'
+          },
+          '-(3)-3': {
+              expected: '-6'
+          },
+          '3^-1^-1': {
+              expected: '1/3'
+          },
+          '-1': {
+              expected: '-1'
+          },
+          '--1': {
+              expected: '1'
+          },
+          '8-1': {
+              expected: '7'
+          },
+          '(-1)': {
+              expected: '-1'
+          },
+          '-(1)-1': {
+              expected: '-2'
+          },
+          '-(-1-1)': {
+              expected: '2'
+          },
+          '-(-1-+1)^2': {
+              expected: '-4'
+          },
+          '-(-1-1+1)': {
+              expected: '1'
+          },
+          '-(1)--(1-1--1)': {
+              expected: '0'
+          },
+          '-(-(1))-(--1)': {
+              expected: '0'
+          },
+          '5^-3': {
+              expected: '1/125'
+          },
+          '5^---3': {
+              expected: '1/125'
+          },
+          '5^-(1--2)': {
+              expected: '1/125'
+          },
+          '5^-(++1+--+2)': {
+              expected: '1/125'
+          },
+          '(5^-(++1+--+2))^-2': {
+              expected: '15625'
+          },
+          '(5^-3^2)': {
+              expected: '1/1953125'
+          },
+          '(5^-3^-2)': {
+              expected: '5^(-1/9)'
+          },
+          '-(5^-3^-2)^-3': {
+              expected: '-5^(1/3)'
+          },
+          '-(--5*--7)': {
+              expected: '-35'
+          },
+          '-(1)--(1-1--1)': {
+              expected: '0'
+          },
+          '(-1)^(3/4)': {
+              expected: '(-1)^(3/4)'
+          }
+      };
+
+        for (var k in cases) {
+            // when
+            var parsed = nerdamer(k);
+
+            // then
+            expect(parsed.toString()).toEqual(cases[k].expected);
+        }
+    });
 });

--- a/spec/core.spec.js
+++ b/spec/core.spec.js
@@ -258,32 +258,32 @@ describe('Nerdamer core', function () {
        var testCases = [
            {
                given: '(1+x^2)!',
-               expected: 'fact(1+x^2)',
+               expected: 'factorial(1+x^2)',
                expectedValue: '245.1516183677083'
            },
            {
                given: '10!',
-               expected: 'fact(10)',
+               expected: 'factorial(10)',
                expectedValue: '3628800'
            },
            {
                given: 'x!',
-               expected: 'fact(x)',
+               expected: 'factorial(x)',
                expectedValue: '2.197620278392476'
            },
            {
                given: 'x!*x!',
-               expected: 'fact(x)^2',
+               expected: 'factorial(x)^2',
                expectedValue: '4.829534888001823'
            },
            {
                given: '3*(1+x!*x!)',
-               expected: '3*(1+fact(x)^2)',
+               expected: '3*(1+factorial(x)^2)',
                expectedValue: '17.488604664005468'
            },
            {
                given: '3*(1+x!*x!)!',
-               expected: '3*fact(1+fact(x)^2)',
+               expected: '3*factorial(1+factorial(x)^2)',
                expectedValue: '1573.2041488172601'
            }
        ];

--- a/spec/core.spec.js
+++ b/spec/core.spec.js
@@ -857,8 +857,7 @@ describe('Nerdamer core', function () {
     });
 
     /** #35 #76: Support multiple minus signs and brackets */
-    // TODO jiggzson: test can be run once #76 is fixed
-    xit('should support prefix operator with parantheses', function () {
+    it('should support prefix operator with parantheses', function () {
       // given
       var testCases = [
         {

--- a/spec/core.spec.js
+++ b/spec/core.spec.js
@@ -284,7 +284,7 @@ describe('Nerdamer core', function () {
            {
                given: '3*(1+x!*x!)!',
                expected: '3*factorial(1+factorial(x)^2)',
-               expectedValue: '1573.2041488172601'
+               expectedValue: '1573.20414881726'
            }
        ];
 


### PR DESCRIPTION
Fixed 2 of 3 failing tests --

One test is remaining and I believe that it is failing for a good reason:

> 2) TeX features should render TeX output correctly
>
>  Message:
    Expected 'x' to equal '\left(x+1\right)!+x!', 'for formula x!+(x+1)!'.
>
>  Stack:
    Error: Expected 'x' to equal '\left(x+1\right)!+x!', 'for formula x!+(x+1)!'.
        at Object.<anonymous> (/home/travis/build/ljacqu/nerdamer/spec/LaTeX.spec.js:161:25)
>
>  Message:
    Expected 'x' to equal '\left(x+1\right)!+x!', 'for formula x!+(x+1)!'.
>
>  Stack:
    Error: Expected 'x' to equal '\left(x+1\right)!+x!', 'for formula x!+(x+1)!'.
        at Object.<anonymous> (/home/travis/build/ljacqu/nerdamer/spec/LaTeX.spec.js:162:32)

This is the following test case:
```js
                given: 'x!+(x+1)!',
                TeX: '\\left(x+1\\right)!+x!',
                decimalTeX: '\\left(x+1\\right)!+x!'
```

Currently, `x` is returned as the TeX result.

This PR also adds the test cases you've provided in https://github.com/jiggzson/nerdamer/pull/78, sorry it took so long to add them. I'm currently relocating and have yet to set everything up.