### PR TITLE
Remove arguments-length check from buildFunction()

### DIFF
--- a/nerdamer.core.js
+++ b/nerdamer.core.js
@@ -5845,7 +5845,6 @@ var nerdamer = (function(imports) {
             return [c.join('*'), xports.join('').replace(/\n+\s+/g, ' ')];
         };
         if(arg_array) { 
-            if(args.length !== arg_array.length) err('Argument array contains wrong number of arguments');
             for(var i=0; i<args.length; i++) {
                 var arg = args[i];
                 if(arg_array.indexOf(arg) === -1) err(arg+' not found in argument array');


### PR DESCRIPTION
For example:
```ts
const f_R2_R = nerdamer('x * y')
const f_R2_Rdx = nerdamer.diff(f_R2_R, 'x')
// error in next line, because f_R2_Rdx isn't dependent on 'y'.
// having the function have two arguments still makes sense though.
const f_R2_rdx_asJSFunction = f_R2_Rdx.buildFunction(['x', 'y'])
```

You could change it to be arglength >= expectedarglength, but the error message that a specific variable is missing is more useful anyways.