### PR TITLE
Support for Product LaTeX, solver toLHS

### DIFF
--- a/Solve.js
+++ b/Solve.js
@@ -99,7 +99,10 @@ if((typeof module) !== 'undefined') {
     // A utility function to parse an expression to left hand side when working with strings
 
     var toLHS = function(eqn) {
-        var es = [eqn.LHS, eqn.RHS];
+        //If it's an equation then call its toLHS function instead
+        if(eqn instanceof Equation)
+            return eqn.toLHS();
+        var es = eqn.split('=');
         if(es[1] === undefined) es[1] = '0';
         var e1 = _.parse(es[0]), e2 = _.parse(es[1]);
         return _.subtract(e1, e2);

--- a/Solve.js
+++ b/Solve.js
@@ -99,7 +99,7 @@ if((typeof module) !== 'undefined') {
     // A utility function to parse an expression to left hand side when working with strings
 
     var toLHS = function(eqn) {
-        var es = eqn.split('=');
+        var es = [eqn.LHS, eqn.RHS];
         if(es[1] === undefined) es[1] = '0';
         var e1 = _.parse(es[0]), e2 = _.parse(es[1]);
         return _.subtract(e1, e2);
@@ -286,7 +286,7 @@ if((typeof module) !== 'undefined') {
      * @param {type} solve_for
      * @returns {Array}
      */
-    var solve = function(eqns, solve_for, solutions) {      
+    var solve = function(eqns, solve_for, solutions) {
         solve_for = solve_for || 'x'; //assumes x by default
         //If it's an array then solve it as a system of equations
         if(isArray(eqns)) {

--- a/nerdamer.core.js
+++ b/nerdamer.core.js
@@ -3387,7 +3387,7 @@ var nerdamer = (function(imports) {
                             f = dx + '\\left(' + expr + '\\right)';
 
                         }
-                        else if (fname === 'sum') {
+                        else if (fname === 'sum' || fname === 'product') {
                             // Split e.args into 4 parts based on locations of , symbols.
                             var argSplit = [[], [], [], []], j = 0, i;
                             for (i = 0; i < e.args.length; i++){
@@ -3398,7 +3398,7 @@ var nerdamer = (function(imports) {
                                 argSplit[j].push(e.args[i]);
                             }
                             // Then build TeX string.
-                            f = '\\sum_'+LaTeX.braces(this.toTeX(argSplit[1])+' = '+this.toTeX(argSplit[2]));
+                            f = (fname==='sum'?'\\sum_':'\\prod_')+LaTeX.braces(this.toTeX(argSplit[1])+' = '+this.toTeX(argSplit[2]));
                             f += '^'+LaTeX.braces(this.toTeX(argSplit[3])) + LaTeX.braces(this.toTeX(argSplit[0]));
                         }
                         else if(fname === FACTORIAL || fname === DOUBLEFACTORIAL) 


### PR DESCRIPTION
Support for product() LaTeX.

solver's toLHS method was expecting string, but getting fed an Equation
object. Altered slightly to keep it from throwing errors.