### PR TITLE
Fix bug with supplemental row in matrix tex representation

### DIFF
--- a/nerdamer.core.js
+++ b/nerdamer.core.js
@@ -5196,7 +5196,10 @@ var nerdamer = (function(imports) {
                     for(var j=0; j<e.length; j++) {
                         rowTeX.push(this.latex(e[j]));
                     }
-                    TeX += rowTeX.join(' & ')+'\\\\\n';
+                    TeX += rowTeX.join(' & ');
+                    if (i<symbol.elements.length-1){    
+                        TeX+='\\\\\n';
+                    }
                 }
                 TeX += '\\end{pmatrix}';
                 return TeX;


### PR DESCRIPTION
There was always an empty row added in matrix tex representation. Removed the empty row.