### PR TITLE
fix problem of atan function when PARSE2NUMBER is true

### DIFF
--- a/nerdamer.core.js
+++ b/nerdamer.core.js
@@ -4015,6 +4015,7 @@ var nerdamer = (function(imports) {
                         return new Symbol(Math.atan(symbol.valueOf()));
                     if(symbol.isImaginary()) 
                         return complex.evaluate(symbol, 'atan');
+                    return _.symfunction('atan', arguments);
                 }
                 else if(symbol.equals(-1))
                     retval = _.parse('-pi/4');


### PR DESCRIPTION
This patch will fix the minor problem exist in atan function, which returns undefined variable when PARSE2NUMBER is true and argument is variable.

Before:
```
> nerdamer.getCore().Settings.PARSE2NUMBER = true;
> nerdamer('atan(x)').text();
TypeError: Cannot read property 'text_' of undefined
    at Expression.text (/home/yosuke/nerdamer/nerdamer.core.js:1853:28)
```

After:
```
> nerdamer.getCore().Settings.PARSE2NUMBER = true;
> nerdamer('atan(x)').text()
'atan(x)'
```