### PR TITLE
Fix bug #442

### DIFF
--- a/nerdamer.core.js
+++ b/nerdamer.core.js
@@ -5971,13 +5971,13 @@ var nerdamer = (function(imports) {
                     retval = _.symfunction(SQRT, [symbol]);
                 }
 
-                if(m) retval = _.multiply(m, retval);
-
-                if(img) retval = _.multiply(img, retval);
-                
                 //put back the sign that was removed earlier
                 if(sign < 0)
                     retval.power.negate();
+
+                if(m) retval = _.multiply(m, retval);
+
+                if(img) retval = _.multiply(img, retval);
             }
             
             if(is_negative && Settings.PARSE2NUMBER)


### PR DESCRIPTION
This a simple fix to #442 bug. It only changes the code from:

`
if(m) retval = _.multiply(m, retval);

if(img) retval = _.multiply(img, retval);
//put back the sign that was removed earlier

if(sign < 0)
      retval.power.negate();`

to 

`
if(sign < 0)
      retval.power.negate();

if(m) retval = _.multiply(m, retval);

if(img) retval = _.multiply(img, retval);
//put back the sign that was removed earlier
`
in line 5974.