### PR TITLE
Fixed an issue where buildFunction for acsc, asec and acot were failing.

### DIFF
--- a/nerdamer.core.js
+++ b/nerdamer.core.js
@@ -960,6 +960,9 @@ var nerdamer = (function(imports) {
         csc: function(x) { return 1/Math.sin(x); },
         sec: function(x) { return 1/Math.cos(x); },
         cot: function(x) { return 1/Math.tan(x); },
+		acsc: function(x) { return 1/Math.asin(1/x); },
+        asec: function(x) { return 1/Math.acos(1/x); },
+        acot: function(x) { return (x < 0)? (Math.PI + Math.atan(1/x)) : (Math.atan(1/x)); },
         // https://gist.github.com/jiggzson/df0e9ae8b3b06ff3d8dc2aa062853bd8
         erf: function(x) {
             var t = 1/(1+0.5*Math.abs(x));

--- a/nerdamer.core.js
+++ b/nerdamer.core.js
@@ -960,7 +960,7 @@ var nerdamer = (function(imports) {
         csc: function(x) { return 1/Math.sin(x); },
         sec: function(x) { return 1/Math.cos(x); },
         cot: function(x) { return 1/Math.tan(x); },
-		acsc: function(x) { return 1/Math.asin(1/x); },
+        acsc: function(x) { return 1/Math.asin(1/x); },
         asec: function(x) { return 1/Math.acos(1/x); },
         acot: function(x) { return (x < 0)? (Math.PI + Math.atan(1/x)) : (Math.atan(1/x)); },
         // https://gist.github.com/jiggzson/df0e9ae8b3b06ff3d8dc2aa062853bd8


### PR DESCRIPTION
buildFunction was calling build where build was relying on Math2 variable to build a function for acsc, asec and acot. There was a bug where these functions were not declared in Math2 variable.