### PR TITLE
acsc bug fix

### DIFF
--- a/nerdamer.core.js
+++ b/nerdamer.core.js
@@ -4327,7 +4327,7 @@ var nerdamer = (function (imports) {
             acsc: function (symbol) {
                 if (Settings.PARSE2NUMBER) {
                     if (symbol.isConstant())
-                        return new Symbol(Math.acos(symbol.invert().valueOf()));
+                        return new Symbol(Math.asin(symbol.invert().valueOf()));
                     if (symbol.isImaginary())
                         return complex.evaluate(symbol, 'acsc');
                 }


### PR DESCRIPTION
Fixed a bug that was causing the acsc to return symbol acos(1/x) instead of asin(1/x) which was causing acsc to have wrong results.