### PR TITLE
feat: enable different ways to show matrix in LaTeX

### DIFF
--- a/nerdamer.core.js
+++ b/nerdamer.core.js
@@ -10042,14 +10042,15 @@ var nerdamer = (function (imports) {
         text: function () {
             return 'matrix(' + this.elements.toString('') + ')';
         },
-        latex: function (option) {
+        latex: function (type = 'v', options) {
+            type = /^$|[bvVp]/.test(type) ? type : 'v';
             var cols = this.cols(), elements = this.elements;
-            return format('\\begin{vmatrix}{0}\\end{vmatrix}', function () {
+            return format('\\begin{' + type + 'matrix}{0}\\end{' + type + 'matrix}', function () {
                 var tex = [];
                 for (var row in elements) {
                     var row_tex = [];
                     for (var i = 0; i < cols; i++) {
-                        row_tex.push(LaTeX.latex.call(LaTeX, elements[row][i], option));
+                        row_tex.push(LaTeX.latex.call(LaTeX, elements[row][i], options));
                     }
                     tex.push(row_tex.join(' & '));
                 }


### PR DESCRIPTION
LaTeX has many ways to display an matrix, let's use.

![image](https://user-images.githubusercontent.com/19750634/67177779-5ce2d100-f3a6-11e9-8735-1fd1dbb9bdbe.png)