### PR TITLE
Disable call peekers

### DIFF
--- a/nerdamer.core.js
+++ b/nerdamer.core.js
@@ -51,6 +51,10 @@ var nerdamer = (function (imports) {
     var CUSTOM_OPERATORS = {};
 
     var Settings = {
+		//Enables/Disables call peekers. False means callPeekers are disabled and true means callPeekers are enabled.
+		callPeekers: false,
+		
+		
         //the max number up to which to cache primes. Making this too high causes performance issues
         init_primes: 1000,
 

--- a/nerdamer.core.js
+++ b/nerdamer.core.js
@@ -5984,7 +5984,7 @@ var nerdamer = (function (imports) {
         };
         
         this.callPeekers = function(name) {
-			if (settings.callPeekers) {
+			if (Settings.callPeekers) {
 				var peekers = this.peekers[name];
 				//remove the first items and stringify
 				var args = arguments2Array(arguments).slice(1).map(stringify);

--- a/nerdamer.core.js
+++ b/nerdamer.core.js
@@ -5984,13 +5984,15 @@ var nerdamer = (function (imports) {
         };
         
         this.callPeekers = function(name) {
-            var peekers = this.peekers[name];
-            //remove the first items and stringify
-            var args = arguments2Array(arguments).slice(1).map(stringify);
-            //call each one of the peekers
-            for(var i=0; i<peekers.length; i++) {
-                peekers[i].apply(null, args);
-            }
+			if (settings.callPeekers) {
+				var peekers = this.peekers[name];
+				//remove the first items and stringify
+				var args = arguments2Array(arguments).slice(1).map(stringify);
+				//call each one of the peekers
+				for(var i=0; i<peekers.length; i++) {
+					peekers[i].apply(null, args);
+				}
+			}
         };
         /*
          * Tokenizes the string


### PR DESCRIPTION
Added a `Settings.callPeekers` variable that is set to false by default.

While `Settings.callPeekers` is set to false, the function this.callPeekers does not execute any code. This push is intended to fix slowdown issues that we had with submitting large number of arguments to nerdamer function such as nerdamer("mean(1000 elements...)").evaluate().text().