### PR TITLE
More convertFromLaTeX Defined Integral types

### DIFF
--- a/nerdamer.core.js
+++ b/nerdamer.core.js
@@ -10883,6 +10883,39 @@ var nerdamer = (function (imports) {
                     }
                     retval += 'defint' + inBrackets(f + ',' + l + ',' + u + ',' + dx);
                 }
+                else if(token.value.startsWith('int_')) {
+                    // var l = parse_next(); // lower
+                    var l = token.value.replace('int_', '')
+                    console.log('uppernow')
+                    i++; // skip the ^
+                    var u = next().value; // upper
+                    // if it is in brackets
+                    if (u === undefined) {
+                        i--;
+                        var u = parse_next();
+                    }
+                    console.log('fnnow')
+                    var f = parse_next(); // function
+                    
+                    // get the variable of integration
+                    var dx = next().value;
+                    // skip the comma
+                    if (dx === ',') {
+                        var dx = next().value;
+                    }
+                    // if 'd', skip
+                    if (dx === 'differentialD') {
+                        // skip the *
+                        i++;
+                        var dx = next().value;
+                    }
+                    if (dx === 'mathrm') {
+                        // skip the mathrm{d}
+                        i++;
+                        var dx = next().value;
+                    }
+                    retval += 'defint' + inBrackets(f + ',' + l + ',' + u + ',' + dx);
+                }
                 else if(token.value === 'mathrm') {
                     var f = tokens[++i][0].value;
                     retval += f + parse_next();
@@ -10921,6 +10954,7 @@ var nerdamer = (function (imports) {
                     }
                 }
                 else {
+                    console.log('falling')
                     if(Array.isArray(token)) {
                         retval += get(LaTeX.parse(token));
                     }
@@ -10929,6 +10963,8 @@ var nerdamer = (function (imports) {
                     }
                 }
             }
+
+            console.log('hm')
 
             return inBrackets(retval);
         }

--- a/nerdamer.core.js
+++ b/nerdamer.core.js
@@ -10954,7 +10954,6 @@ var nerdamer = (function (imports) {
                     }
                 }
                 else {
-                    console.log('falling')
                     if(Array.isArray(token)) {
                         retval += get(LaTeX.parse(token));
                     }
@@ -10963,8 +10962,6 @@ var nerdamer = (function (imports) {
                     }
                 }
             }
-
-            console.log('hm')
 
             return inBrackets(retval);
         }

--- a/nerdamer.core.js
+++ b/nerdamer.core.js
@@ -10862,18 +10862,25 @@ var nerdamer = (function (imports) {
                     var l = parse_next(); // lower
                     i++; // skip the ^
                     var u = parse_next(); // upper
-                    var f = parse_next();
-                    // skip the comma
-                    i++;
+                    var f = parse_next(); // function
+                    
                     // get the variable of integration
                     var dx = next().value;
+                    // skip the comma
+                    if (dx === ',') {
+                        var dx = next().value;
+                    }
                     // if 'd', skip
                     if (dx === 'differentialD') {
                         // skip the *
                         i++;
                         var dx = next().value;
                     }
-                    // var dx = parse_next();
+                    if (dx === 'mathrm') {
+                        // skip the mathrm{d}
+                        i++;
+                        var dx = next().value;
+                    }
                     retval += 'defint' + inBrackets(f + ',' + l + ',' + u + ',' + dx);
                 }
                 else if(token.value === 'mathrm') {
@@ -12135,11 +12142,7 @@ var nerdamer = (function (imports) {
      * @returns {String}
      */
     libExports.convertFromLaTeX = function (e) {
-        console.log('cFL - e:', e)
-        console.log('cFL - tokenized:', _.tokenize(e))
         var txt = LaTeX.parse(_.tokenize(e));
-        console.log('cFL - LaTeX.parsed:', txt)
-        console.log('cFL - _.parsed:',_.parse(txt))
         return new Expression(_.parse(txt));
     };
 

--- a/nerdamer.core.js
+++ b/nerdamer.core.js
@@ -10861,7 +10861,12 @@ var nerdamer = (function (imports) {
                 else if(token.value === 'int_') {
                     var l = parse_next(); // lower
                     i++; // skip the ^
-                    var u = parse_next(); // upper
+                    var u = next().value; // upper
+                    // if it is in brackets
+                    if (u === undefined) {
+                        i--;
+                        var u = parse_next();
+                    }
                     var f = parse_next(); // function
                     
                     // get the variable of integration
@@ -10894,7 +10899,6 @@ var nerdamer = (function (imports) {
                         i--;
                         var u = parse_next();
                     }
-                    console.log('fnnow')
                     var f = parse_next(); // function
                     
                     // get the variable of integration

--- a/nerdamer.core.js
+++ b/nerdamer.core.js
@@ -10888,7 +10888,7 @@ var nerdamer = (function (imports) {
                     }
                     retval += 'defint' + inBrackets(f + ',' + l + ',' + u + ',' + dx);
                 }
-                else if(token.value.startsWith('int_')) {
+                else if(token.value && token.value.startsWith('int_')) {
                     // var l = parse_next(); // lower
                     var l = token.value.replace('int_', '')
                     console.log('uppernow')


### PR DESCRIPTION
Add parsing where begin and end integral are not in brackets.
`\\int_0^{\\pi}(\sin(x)),dx`
`\\int_0^1(\\sin(x)),dx`
`\\int_{\\pi}^1(\\sin(x)),dx'`