### PR TITLE
expose prepareExpression and change the name to match other functions

### DIFF
--- a/nerdamer.core.js
+++ b/nerdamer.core.js
@@ -6111,7 +6111,7 @@ var nerdamer = (function (imports) {
          * sending to the parser
          * @param {String} e
          */
-        var prepare_expression = function (e) {
+        this.prepareExpression = function (e) {
             /*
              * Since variables cannot start with a number, the assumption is made that when this occurs the
              * user intents for this to be a coefficient. The multiplication symbol in then added. The same goes for
@@ -6937,7 +6937,7 @@ var nerdamer = (function (imports) {
             return Q[0];
         };
         this.parse = function (e, substitutions) {
-            e = prepare_expression(e);
+            e = this.prepareExpression(e);
             substitutions = substitutions || {};
             //three passes but easier to debug
             var tokens = this.tokenize(e);


### PR DESCRIPTION
Exposing prepareExpression would allow someone to run the parse command by hand (prepare, tokenize, toRPN, parseRPN) and also make changes to the tokens/RPN if needed.

I'm pretty sure this covers everything needed to expose prepare_expression. Based on the other methods in the parser, I renamed prepare_expression to prepareExpression.